### PR TITLE
Added capturing to remove so that captured events can be removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ crossvent.add(document.body, 'click', function (e) {
 });
 ```
 
-### `crossvent.remove(el, type, fn)`
+### `crossvent.remove(el, type, fn, capturing?)`
 
 Removes an event listener `fn` of type `type` from DOM element `el`.
 

--- a/src/crossvent.js
+++ b/src/crossvent.js
@@ -17,8 +17,8 @@ function addEventHard (el, type, fn, capturing) {
   return el.attachEvent('on' + type, wrap(el, type, fn), capturing);
 }
 
-function removeEventEasy (el, type, fn) {
-  return el.removeEventListener(type, fn);
+function removeEventEasy (el, type, fn, capturing) {
+  return el.removeEventListener(type, fn, capturing);
 }
 
 function removeEventHard (el, type, fn) {


### PR DESCRIPTION
As per [MSDN](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener):

"Removal of a capturing listener does not affect a non-capturing version of the same listener, and vice versa."

Currently it's not possible to remove capture events using this library.
