### PR TITLE
fix(package): update custom-event version to support non-browser environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "vinyl-source-stream": "^0.1.1"
   },
   "dependencies": {
-    "custom-event": "^1.0.0"
+    "custom-event": "^1.0.1"
   }
 }


### PR DESCRIPTION
`custom-event` version `1.0.1` adds a `'undefined' !== typeof document` to make it requirable in non-browser environments